### PR TITLE
fix one doc mistake of tutorial

### DIFF
--- a/docs/bb-note/src/tutorial/tutorial.md
+++ b/docs/bb-note/src/tutorial/tutorial.md
@@ -14,7 +14,7 @@ Chisel学习资源：[binder](https://mybinder.org/v2/gh/freechipsproject/chisel
 
 ```
 cd /path/to/buckyball  
-source env.sh
+source ./env.sh
 // 全文所有路径都是以./buckyball为起点的相对路径
 ```
 


### PR DESCRIPTION
I asked this question in the WeChat group before. If you enter source env.sh, you will get an error. If you change it to source ./env.sh, there will be no problem.