### PR TITLE
[bb-test] fix: add the missing function of compare expected matrix with output in transferball and reluball

### DIFF
--- a/bb-tests/workloads/src/CTest/toy/buckyball.c
+++ b/bb-tests/workloads/src/CTest/toy/buckyball.c
@@ -245,6 +245,19 @@ void cpu_matmul(elem_t *a, elem_t *b, result_t *c, int rows, int cols,
   }
 }
 
+// CPU ReLU activation function
+void cpu_relu(elem_t *a, elem_t *matrix, int rows, int cols) {
+  for (int i = 0; i < rows * cols; i++) {
+    matrix[i] = (a[i] > 0) ? a[i] : 0;
+  }
+}
+
+// CPU transfer from elem_t to result_t
+void cpu_transfer(elem_t *src, elem_t *dst, int rows, int cols) {
+  for (int i = 0; i < rows * cols; i++) {
+    dst[i] = (result_t)src[i];
+  }
+}
 unsigned long long read_cycle(void) {
   unsigned long long c;
   asm volatile("csrr %0, cycle" : "=r"(c));

--- a/bb-tests/workloads/src/CTest/toy/buckyball.h
+++ b/bb-tests/workloads/src/CTest/toy/buckyball.h
@@ -73,6 +73,8 @@ void transpose_u8_matrix(elem_t *src, elem_t *dst, int rows, int cols);
 void transpose_u32_matrix(result_t *src, result_t *dst, int rows, int cols);
 void cpu_matmul(elem_t *a, elem_t *b, result_t *c, int rows, int cols,
                 int inner);
+void cpu_relu(elem_t *a, elem_t *matrix, int rows, int cols);
+void cpu_transfer(elem_t *src, elem_t *dst, int rows, int cols);
 
 unsigned long long read_cycle(void);
 #endif


### PR DESCRIPTION
add the function of compare expected matrix with output in transferball and reluball. They all passed the test, verifying that expected ones equals to output ones