### PR TITLE
Add switcher module

### DIFF
--- a/arch/src/main/scala/framework/blink/blink.scala
+++ b/arch/src/main/scala/framework/blink/blink.scala
@@ -25,6 +25,7 @@ class Status extends Bundle {
   val iter = Output(UInt(32.W))
 }
 
+
 // SramReadIO with rob_id
 class SramReadWithRobId(val n: Int, val w: Int)(implicit b: CustomBuckyballConfig, p: Parameters) extends Bundle {
   val io = new SramReadIO(n, w)
@@ -35,9 +36,28 @@ class SramReadWithRobId(val n: Int, val w: Int)(implicit b: CustomBuckyballConfi
 // SramWriteIO with rob_id
 class SramWriteWithRobId(val n: Int, val w: Int, val mask_len: Int)(implicit b: CustomBuckyballConfig, p: Parameters) extends Bundle {
   val io = new SramWriteIO(n, w, mask_len)
-  // Input because the outer layer has Flipped
+  // Input because theSramWriteIO outer layer has Flipped
   val rob_id = Input(UInt(log2Up(b.rob_entries).W))
 }
+
+// SramReadIO with rob_id
+class SramReadWithInfo(val n: Int, val w: Int)(implicit b: CustomBuckyballConfig, p: Parameters) extends Bundle {
+  val io = new SramReadIO(n, w)
+  // Input because the outer layer has Flipped
+  val rob_id = Input(UInt(log2Up(b.rob_entries).W))
+  val is_acc = Input(Bool())
+  val bank_id = Input(UInt(log2Up(b.sp_banks+b.acc_banks).W))
+}
+
+// SramWriteIO with rob_id
+class SramWriteWithInfo(val n: Int, val w: Int, val mask_len: Int)(implicit b: CustomBuckyballConfig, p: Parameters) extends Bundle {
+  val io = new SramWriteIO(n, w, mask_len)
+  // Input because theSramWriteIO outer layer has Flipped
+  val rob_id = Input(UInt(log2Up(b.rob_entries).W))
+  val is_acc = Input(Bool())
+  val bank_id = Input(UInt(log2Up(b.sp_banks+b.acc_banks).W))
+}
+
 
 // Standard interface for Ball devices
 class Blink(implicit b: CustomBuckyballConfig, p: Parameters) extends Bundle {

--- a/arch/src/main/scala/framework/switcher/README.md
+++ b/arch/src/main/scala/framework/switcher/README.md
@@ -1,0 +1,69 @@
+# Switcher Module
+
+This directory contains two small but critical adapters that translate between Ball devices' physical memory ports and a unified "virtual line" representation.
+
+- `ToVirtualLine`: Merges SPAD/ACC physical ports into a uniform virtual interface carrying metadata (`is_acc`, `bank_id`, `rob_id`).
+- `ToPhysicalLine`: Restores the virtual interface back into physical SPAD/ACC ports, preserving data and `rob_id`.
+
+## Goals
+- **Unified view**: Provide a single, consistent interface for memory requests and responses regardless of origin (SPAD or ACC).
+- **Explicit metadata**: Attach `is_acc`, `bank_id`, and `rob_id` so downstream routing and accounting are straightforward.
+- **Clear behavior**: Support either bank-sharing with arbitration or segmented direct mapping, depending on system choice.
+- **Type correctness**: Keep widths and masks consistent; no implicit format conversions.
+
+## Interfaces
+- Physical ports:
+  - `SramReadWithRobId(n, w)`: wraps `SramReadIO(n, w)` plus `rob_id`.
+  - `SramWriteWithRobId(n, w, mask_len)`: wraps `SramWriteIO(n, w, mask_len)` plus `rob_id`.
+- Virtual ports:
+  - `SramReadWithInfo(n, w)`: `SramReadIO` plus `rob_id`, `is_acc` (Bool), `bank_id`.
+  - `SramWriteWithInfo(n, w, mask_len)`: `SramWriteIO` plus the same metadata.
+- Widths:
+  - `rob_id` depends on `b.rob_entries`.
+  - `bank_id` wide enough for `b.sp_banks + b.acc_banks`.
+  - `is_acc` is a `Bool`.
+
+## ToVirtualLine
+- Inputs:
+  - `sramRead_i/sramWrite_i`: size `b.sp_banks`.
+  - `accRead_i/accWrite_i`: size `b.acc_banks`.
+- Outputs:
+  - `sramRead_o/sramWrite_o`: virtual lines.
+- Port count (choose one design and keep consistent):
+  - **Max** design: `numBanks = max(b.sp_banks, b.acc_banks)`. Shared banks arbitrate (typically SPAD priority); tail banks connect to whichever exists.
+  - **Sum** design: `numBanks = b.sp_banks + b.acc_banks`. Lower range maps SPAD; upper range maps ACC. No arbitration; direct mapping with metadata.
+- Read path:
+  - Drive `req` from physical to virtual; broadcast `resp` from virtual to the selected physical endpoint, using `ready` to consume.
+  - Set `rob_id/is_acc/bank_id` based on origin and index. Use `false.B/true.B` for `is_acc`.
+- Write path:
+  - Map write `addr/data/mask` and metadata to virtual lines.
+  - No `resp` channel on writes; only handshake and field mapping.
+
+## ToPhysicalLine
+- Inputs:
+  - `sramRead_i/sramWrite_i`: virtual lines (same size as ToVirtualLine outputs).
+- Outputs:
+  - `sramRead_o/sramWrite_o`: size `b.sp_banks`.
+  - `accRead_o/accWrite_o`: size `b.acc_banks`.
+- Routing:
+  - **Max** design: Use `is_acc` and `bank_id` to select the ACC bank; SPAD uses the virtual index `i`.
+  - **Sum** design: Lower (SPAD) and upper (ACC) segments map 1:1 back to physical ports; `bank_id` marks the internal index.
+- Timing notes:
+  - If read `resp` and meta signals form a combinational loop, consider `RegNext` on meta to break it.
+
+## Integration
+- In `bbus`, each Ball connects physical ports → `ToVirtualLine` → virtual interface.
+- Then `ToPhysicalLine` restores to physical ports that connect to `MemRouter`.
+- If a strict direct-connect behavior is desired, use the **Sum** design and ensure both sides agree on vector sizes.
+
+## Common Pitfalls
+- Assigning `0.U/1.U` to `is_acc` (must be `false.B/true.B`).
+- Using `io.sramRead_i(j)` instead of `io.accRead_i(i)` for ACC reads.
+- Typos like `b.acc_Banks` (should be `b.acc_banks`).
+- Dangling logical operators (e.g., trailing `||`) causing compile errors.
+- Missing write-path mapping, leaving `ready` low and blocking writes.
+
+## Recommendations
+- Decide upfront: **Max + arbitration** vs **Sum + segmented direct mapping** and keep both modules and top-level wiring consistent.
+- Align priority policy (SPAD vs ACC) with system requirements if using shared-bank arbitration.
+- Keep `rob_id` and `bank_id` consistent to avoid accounting and replay issues.

--- a/arch/src/main/scala/framework/switcher/ToPhysicalLine.scala
+++ b/arch/src/main/scala/framework/switcher/ToPhysicalLine.scala
@@ -1,0 +1,149 @@
+package framework.switcher
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import examples.BuckyballConfigs.CustomBuckyballConfig
+import framework.memdomain.mem.{SramReadIO, SramWriteIO}
+import framework.blink.{SramReadWithRobId, SramWriteWithRobId, SramReadWithInfo, SramWriteWithInfo}
+
+class ToPhysicalLine(implicit b: CustomBuckyballConfig, p: Parameters) extends Module {
+
+  private val numBanks = b.sp_banks + b.acc_banks
+
+  val io = IO(new Bundle {
+    // Unified virtual input ports (from ToVirtualLine)
+    val sramRead_i  = Vec(numBanks, new SramReadWithInfo(b.spad_bank_entries, b.spad_w))
+    val sramWrite_i = Vec(numBanks, new SramWriteWithInfo(b.spad_bank_entries, b.spad_w, b.spad_mask_len))
+
+    // Physical memory endpoints
+    val sramRead_o  = Vec(b.sp_banks, Flipped(new SramReadWithRobId(b.spad_bank_entries, b.spad_w)))
+    val sramWrite_o = Vec(b.sp_banks, Flipped(new SramWriteWithRobId(b.spad_bank_entries, b.spad_w, b.spad_mask_len)))
+
+    val accRead_o   = Vec(b.acc_banks, Flipped(new SramReadWithRobId(b.acc_bank_entries, b.acc_w)))
+    val accWrite_o  = Vec(b.acc_banks, Flipped(new SramWriteWithRobId(b.acc_bank_entries, b.acc_w, b.acc_mask_len)))
+  })
+
+  // --------------------------------------------------------------------------
+  // Default initialization for all physical ports
+  // --------------------------------------------------------------------------
+
+  // SPAD read/write ports
+  for (i <- 0 until b.sp_banks) {
+    val spR = io.sramRead_o(i)
+    spR.io.req.valid  := false.B
+    spR.io.req.bits   := DontCare
+    spR.io.resp.ready := false.B
+    spR.rob_id        := 0.U
+
+    val spW = io.sramWrite_o(i)
+    spW.io.req.valid := false.B
+    spW.io.req.bits  := DontCare
+    spW.rob_id       := 0.U
+  }
+
+  // ACC read/write ports
+  for (i <- 0 until b.acc_banks) {
+    val accR = io.accRead_o(i)
+    accR.io.req.valid  := false.B
+    accR.io.req.bits   := DontCare
+    accR.io.resp.ready := false.B
+    accR.rob_id        := 0.U
+
+    val accW = io.accWrite_o(i)
+    accW.io.req.valid := false.B
+    accW.io.req.bits  := DontCare
+    accW.rob_id       := 0.U
+  }
+
+  // Default values for all virtual ports
+  for (i <- 0 until numBanks) {
+    val vR = io.sramRead_i(i)
+    vR.io.req.ready  := false.B
+    vR.io.resp.valid := false.B
+    vR.io.resp.bits  := DontCare
+
+    val vW = io.sramWrite_i(i)
+    vW.io.req.ready := false.B
+  }
+
+  // --------------------------------------------------------------------------
+  // Read routing: virtual → SPAD   (indices 0 .. sp_banks-1)
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until b.sp_banks) {
+    val vR  = io.sramRead_i(i)
+    val spR = io.sramRead_o(i)
+
+    // Request path (virtual → SPAD)
+    spR.io.req.valid        := vR.io.req.valid
+    spR.io.req.bits.addr    := vR.io.req.bits.addr
+    spR.io.req.bits.fromDMA := vR.io.req.bits.fromDMA
+    spR.rob_id              := vR.rob_id
+
+    vR.io.req.ready         := spR.io.req.ready
+
+    // Response path (SPAD → virtual)
+    vR.io.resp.valid        := spR.io.resp.valid
+    vR.io.resp.bits         := spR.io.resp.bits
+    spR.io.resp.ready       := vR.io.resp.ready
+  }
+
+  // --------------------------------------------------------------------------
+  // Read routing: virtual → ACC  (indices sp_banks .. sp_banks+acc_banks-1)
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until b.acc_banks) {
+    val idx  = i + b.sp_banks
+    val vR   = io.sramRead_i(idx)
+    val accR = io.accRead_o(i)
+
+    // Request path (virtual → ACC)
+    accR.io.req.valid        := vR.io.req.valid
+    accR.io.req.bits.addr    := vR.io.req.bits.addr
+    accR.io.req.bits.fromDMA := vR.io.req.bits.fromDMA
+    accR.rob_id              := vR.rob_id
+
+    vR.io.req.ready          := accR.io.req.ready
+
+    // Response path (ACC → virtual)
+    vR.io.resp.valid         := accR.io.resp.valid
+    vR.io.resp.bits          := accR.io.resp.bits
+    accR.io.resp.ready       := vR.io.resp.ready
+  }
+
+  // --------------------------------------------------------------------------
+  // Write routing: virtual → SPAD
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until b.sp_banks) {
+    val vW  = io.sramWrite_i(i)
+    val spW = io.sramWrite_o(i)
+
+    spW.io.req.valid       := vW.io.req.valid
+    spW.io.req.bits.addr   := vW.io.req.bits.addr
+    spW.io.req.bits.data   := vW.io.req.bits.data
+    spW.io.req.bits.mask   := vW.io.req.bits.mask
+    spW.rob_id             := vW.rob_id
+
+    vW.io.req.ready        := spW.io.req.ready
+  }
+
+  // --------------------------------------------------------------------------
+  // Write routing: virtual → ACC
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until b.acc_banks) {
+    val idx  = i + b.sp_banks
+    val vW   = io.sramWrite_i(idx)
+    val accW = io.accWrite_o(i)
+
+    accW.io.req.valid       := vW.io.req.valid
+    accW.io.req.bits.addr   := vW.io.req.bits.addr
+    accW.io.req.bits.data   := vW.io.req.bits.data
+    accW.io.req.bits.mask   := vW.io.req.bits.mask
+    accW.rob_id             := vW.rob_id
+
+    vW.io.req.ready         := accW.io.req.ready
+  }
+}

--- a/arch/src/main/scala/framework/switcher/ToVirtuaLine.scala
+++ b/arch/src/main/scala/framework/switcher/ToVirtuaLine.scala
@@ -1,0 +1,167 @@
+package framework.switcher
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import examples.BuckyballConfigs.CustomBuckyballConfig
+import framework.memdomain.mem.{SramReadIO, SramWriteIO, SramReadReq, SramReadResp, SramWriteReq}
+import framework.blink.{SramReadWithRobId, SramWriteWithRobId, SramReadWithInfo, SramWriteWithInfo}
+
+class ToVirtualLine(implicit b: CustomBuckyballConfig, p: Parameters) extends Module {
+  // Total number of unified virtual banks = sp_banks + acc_banks
+  private val numBanks = b.sp_banks + b.acc_banks
+
+  val io = IO(new Bundle {
+    // Physical SRAM/ACC ports
+    val sramRead_i  = Vec(b.sp_banks, new SramReadWithRobId(b.spad_bank_entries, b.spad_w))
+    val sramWrite_i = Vec(b.sp_banks, new SramWriteWithRobId(b.spad_bank_entries, b.spad_w, b.spad_mask_len))
+    val accRead_i   = Vec(b.acc_banks, new SramReadWithRobId(b.acc_bank_entries, b.acc_w))
+    val accWrite_i  = Vec(b.acc_banks, new SramWriteWithRobId(b.acc_bank_entries, b.acc_w, b.acc_mask_len))
+
+    // Unified virtual interface
+    val sramRead_o  = Vec(numBanks, Flipped(new SramReadWithInfo(b.spad_bank_entries, b.spad_w)))
+    val sramWrite_o = Vec(numBanks, Flipped(new SramWriteWithInfo(b.spad_bank_entries, b.spad_w, b.spad_mask_len)))
+  })
+
+  // --------------------------------------------------------------------------
+  // Default initialization for virtual output banks
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until numBanks) {
+    val vr = io.sramRead_o(i)
+    vr.io.req.valid  := false.B
+    vr.io.req.bits   := DontCare
+    vr.io.resp.ready := false.B
+    vr.is_acc        := false.B
+    vr.bank_id       := 0.U
+    vr.rob_id        := 0.U
+
+    val vw = io.sramWrite_o(i)
+    vw.io.req.valid := false.B
+    vw.io.req.bits  := DontCare
+    vw.is_acc       := false.B
+    vw.bank_id      := 0.U
+    vw.rob_id       := 0.U
+  }
+
+  // Default init for physical inputs
+  for (i <- 0 until b.sp_banks) {
+    val spR = io.sramRead_i(i)
+    spR.io.req.ready  := false.B
+    spR.io.resp.valid := false.B
+    spR.io.resp.bits  := DontCare
+
+    val spW = io.sramWrite_i(i)
+    spW.io.req.ready := false.B
+  }
+
+  for (i <- 0 until b.acc_banks) {
+    val accR = io.accRead_i(i)
+    accR.io.req.ready  := false.B
+    accR.io.resp.valid := false.B
+    accR.io.resp.bits  := DontCare
+
+    val accW = io.accWrite_i(i)
+    accW.io.req.ready := false.B
+  }
+
+  // --------------------------------------------------------------------------
+  // Read Path Routing: SPAD → virtual line (low bank index range)
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until b.sp_banks) {
+    val vR   = io.sramRead_o(i)
+    val sp   = io.sramRead_i(i)
+    val spRq = sp.io.req
+
+    val selSp = spRq.valid
+
+    vR.io.req.valid        := selSp
+    spRq.ready             := selSp && vR.io.req.ready
+
+    vR.io.req.bits.addr    := spRq.bits.addr
+    vR.io.req.bits.fromDMA := spRq.bits.fromDMA
+
+    vR.is_acc              := false.B
+    vR.bank_id             := i.U(vR.bank_id.getWidth.W)
+    vR.rob_id              := sp.rob_id
+
+    sp.io.resp.valid       := vR.io.resp.valid
+    sp.io.resp.bits        := vR.io.resp.bits
+    vR.io.resp.ready       := sp.io.resp.ready && selSp
+  }
+
+  // --------------------------------------------------------------------------
+  // Read Path Routing: ACC → virtual line (higher bank index range)
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until b.acc_banks) {
+    val j = i + b.sp_banks
+    val vR   = io.sramRead_o(j)
+    val acc  = io.accRead_i(i)
+    val accRq = acc.io.req
+
+    val selAcc = accRq.valid
+
+    vR.io.req.valid        := selAcc
+    accRq.ready            := selAcc && vR.io.req.ready
+
+    vR.io.req.bits.addr    := accRq.bits.addr
+    vR.io.req.bits.fromDMA := accRq.bits.fromDMA
+
+    vR.is_acc              := true.B
+    vR.bank_id             := i.U(vR.bank_id.getWidth.W)
+    vR.rob_id              := acc.rob_id
+
+    acc.io.resp.valid      := vR.io.resp.valid
+    acc.io.resp.bits       := vR.io.resp.bits
+    vR.io.resp.ready       := acc.io.resp.ready && selAcc
+  }
+
+  // --------------------------------------------------------------------------
+  // Write Path Routing: SPAD → virtual line
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until b.sp_banks) {
+    val vW   = io.sramWrite_o(i)
+    val sp   = io.sramWrite_i(i)
+    val spRq = sp.io.req
+
+    val selSp = spRq.valid
+
+    vW.io.req.valid      := selSp
+    spRq.ready           := selSp && vW.io.req.ready
+
+    vW.io.req.bits.addr  := spRq.bits.addr
+    vW.io.req.bits.data  := spRq.bits.data
+    vW.io.req.bits.mask  := spRq.bits.mask
+
+    vW.is_acc            := false.B
+    vW.bank_id           := i.U(vW.bank_id.getWidth.W)
+    vW.rob_id            := sp.rob_id
+  }
+
+  // --------------------------------------------------------------------------
+  // Write Path Routing: ACC → virtual line
+  // --------------------------------------------------------------------------
+
+  for (i <- 0 until b.acc_banks) {
+    val j = i + b.sp_banks
+    val vW    = io.sramWrite_o(j)
+    val acc   = io.accWrite_i(i)
+    val accRq = acc.io.req
+
+    val selAcc = accRq.valid
+
+    vW.io.req.valid      := selAcc
+    accRq.ready          := selAcc && vW.io.req.ready
+
+    vW.io.req.bits.addr  := accRq.bits.addr
+    vW.io.req.bits.data  := accRq.bits.data
+    vW.io.req.bits.mask  := accRq.bits.mask
+
+    vW.is_acc            := true.B
+    vW.bank_id           := i.U(vW.bank_id.getWidth.W)
+    vW.rob_id            := acc.rob_id
+  }
+}


### PR DESCRIPTION
The swicher directory contains two small but critical adapters that translate between Ball devices' physical memory ports and a unified "virtual line" representation.

- `ToVirtualLine`: Merges SPAD/ACC physical ports into a uniform virtual interface carrying metadata (`is_acc`, `bank_id`, `rob_id`).
- `ToPhysicalLine`: Restores the virtual interface back into physical SPAD/ACC ports, preserving data and `rob_id`.

This module is used to adapt to undeveloped parts during the development of unified virtualization of the development bus, thereby facilitating debugging.