### PR TITLE
Fix multicore shared-memory query routing and add Goban regressions

### DIFF
--- a/arch/src/main/scala/framework/memdomain/MemDomain.scala
+++ b/arch/src/main/scala/framework/memdomain/MemDomain.scala
@@ -47,6 +47,7 @@ class MemDomain(val b: GlobalConfig)(edge: TLEdgeOut) extends Module {
 // Shared memory path
     val shared_mem_req           = Vec(SharedMemLayout.channelPerHart(b), new MemRequestIO(b))
     val shared_config            = Decoupled(new MemConfigerIO(b))
+    val shared_query_valid       = Output(Bool())
     val shared_query_vbank_id    = Output(UInt(8.W))
     val shared_query_group_count = Input(UInt(log2Up(b.memDomain.bankNum + 1).W))
   })
@@ -64,6 +65,7 @@ class MemDomain(val b: GlobalConfig)(edge: TLEdgeOut) extends Module {
 
   // Shared query: backend delegates shared query to external SharedMemBackend
   backend.io.shared_query_group_count := io.shared_query_group_count
+  io.shared_query_valid               := backend.io.shared_query_valid
   io.shared_query_vbank_id            := backend.io.shared_query_vbank_id
 
 //===----------------------------------------------------------------------===//

--- a/arch/src/main/scala/framework/memdomain/backend/MemBackend.scala
+++ b/arch/src/main/scala/framework/memdomain/backend/MemBackend.scala
@@ -22,6 +22,7 @@ class MemBackend(val b: GlobalConfig) extends Module {
     val shared_config  = Decoupled(new MemConfigerIO(b))
 
     // Query interface: shared query goes out, private query handled internally.
+    val shared_query_valid       = Output(Bool())
     val shared_query_vbank_id    = Output(UInt(8.W))
     val shared_query_group_count = Input(UInt(log2Up(b.memDomain.bankNum + 1).W))
 
@@ -54,6 +55,7 @@ class MemBackend(val b: GlobalConfig) extends Module {
 
   // Query routing
   privateBackend.io.query_vbank_id := io.query_vbank_id
+  io.shared_query_valid            := io.query_is_shared
   io.shared_query_vbank_id         := io.query_vbank_id
   io.query_group_count             := Mux(io.query_is_shared, io.shared_query_group_count, privateBackend.io.query_group_count)
 

--- a/arch/src/main/scala/framework/memdomain/backend/shared/SharedMemBackend.scala
+++ b/arch/src/main/scala/framework/memdomain/backend/shared/SharedMemBackend.scala
@@ -21,8 +21,10 @@ class SharedMemBackend(val b: GlobalConfig) extends Module {
     val config  = Flipped(Decoupled(new MemConfigerIO(b)))
 
     // Query interface for frontend to get group count
-    val query_vbank_id    = Input(UInt(8.W))
-    val query_group_count = Output(UInt(log2Up(b.memDomain.bankNum + 1).W))
+    val query_valid       = Input(Vec(nCores, Bool()))
+    val query_hart_id     = Input(Vec(nCores, UInt(b.core.xLen.W)))
+    val query_vbank_id    = Input(Vec(nCores, UInt(8.W)))
+    val query_group_count = Output(Vec(nCores, UInt(log2Up(b.memDomain.bankNum + 1).W)))
   })
 
   val banks:    Seq[Instance[SramBank]] = Seq.fill(totalBanks)(Instantiate(new SramBank(b)))
@@ -69,6 +71,16 @@ class SharedMemBackend(val b: GlobalConfig) extends Module {
     is_multi: Bool,
     group_id: UInt
   ): Unit = {
+    val duplicate = mappingTable.map(entry =>
+      entry.valid &&
+        (entry.hart_id === hart_id) &&
+        (entry.vbank_id === vbank_id) &&
+        (entry.group_id === group_id)
+    ).reduce(_ || _)
+    when(duplicate) {
+      assert(false.B, "SharedMemBackend duplicate allocation: hart=%d vbank=%d group=%d\n", hart_id, vbank_id, group_id)
+    }
+
     val entry = mappingTable(pbank_id)
     entry.valid    := true.B
     entry.hart_id  := hart_id
@@ -78,6 +90,13 @@ class SharedMemBackend(val b: GlobalConfig) extends Module {
   }
 
   def deleteEntry(hart_id: UInt, vbank_id: UInt): Unit = {
+    val found = mappingTable.map(entry =>
+      entry.valid && entry.vbank_id === vbank_id && entry.hart_id === hart_id
+    ).reduce(_ || _)
+    when(!found) {
+      assert(false.B, "SharedMemBackend release missing allocation: hart=%d vbank=%d\n", hart_id, vbank_id)
+    }
+
     for (i <- 0 until totalBanks) {
       when(mappingTable(i).valid && mappingTable(i).vbank_id === vbank_id && mappingTable(i).hart_id === hart_id) {
         mappingTable(i).valid := false.B
@@ -86,6 +105,11 @@ class SharedMemBackend(val b: GlobalConfig) extends Module {
   }
 
   def getFreePbankId(): UInt = {
+    val hasFree = mappingTable.map(_.valid === false.B).reduce(_ || _)
+    when(!hasFree) {
+      assert(false.B, "SharedMemBackend allocation failed: no free physical shared bank\n")
+    }
+
     val freePbankId = mappingTable.indexWhere(_.valid === false.B)
     freePbankId
   }
@@ -133,14 +157,22 @@ class SharedMemBackend(val b: GlobalConfig) extends Module {
 
   when(io.config.fire) {
     when(io.config.bits.alloc) {
+      val pbankId = getFreePbankId()
+      printf(
+        p"[SharedMemBackend][ALLOC] hart=${io.config.bits.hart_id} vbank=0x${Hexadecimal(io.config.bits.vbank_id)} " +
+          p"group=${io.config.bits.group_id} pbank=${pbankId} is_multi=${io.config.bits.is_multi}\n"
+      )
       addEntry(
         io.config.bits.hart_id,
         io.config.bits.vbank_id,
-        getFreePbankId(),
+        pbankId,
         io.config.bits.is_multi,
         io.config.bits.group_id
       )
     }.otherwise {
+      printf(
+        p"[SharedMemBackend][RELEASE] hart=${io.config.bits.hart_id} vbank=0x${Hexadecimal(io.config.bits.vbank_id)}\n"
+      )
       deleteEntry(io.config.bits.hart_id, io.config.bits.vbank_id)
     }
   }
@@ -148,13 +180,25 @@ class SharedMemBackend(val b: GlobalConfig) extends Module {
   // -----------------------------------------------------------------------------
   // Query interface: return group count for a given vbank_id
   // -----------------------------------------------------------------------------
-  val groupCounts = mappingTable.map { entry =>
-    val matches = entry.valid && (entry.vbank_id === io.query_vbank_id)
-    val count   = Mux(entry.is_multi, entry.group_id +& 1.U, 1.U)
-    Mux(matches, count, 0.U)
-  }
+  for (q <- 0 until nCores) {
+    val groupCounts = mappingTable.map { entry =>
+      val matches = io.query_valid(q) &&
+        entry.valid &&
+        (entry.hart_id === io.query_hart_id(q)) &&
+        (entry.vbank_id === io.query_vbank_id(q))
+      val count = Mux(entry.is_multi, entry.group_id +& 1.U, 1.U)
+      Mux(matches, count, 0.U)
+    }
 
-  io.query_group_count := groupCounts.reduce((a, b) => Mux(a > b, a, b))
+    io.query_group_count(q) := groupCounts.reduce((a, b) => Mux(a > b, a, b))
+    val queryHit = groupCounts.map(_ =/= 0.U).reduce(_ || _)
+    when(io.query_valid(q) && !queryHit) {
+      printf(
+        p"[SharedMemBackend][QUERY_MISS] q=$q hart=${io.query_hart_id(q)} " +
+          p"vbank=0x${Hexadecimal(io.query_vbank_id(q))} returned group_count=0\n"
+      )
+    }
+  }
 
   // -----------------------------------------------------------------------------
   // Connect AccPipe and Banks

--- a/arch/src/main/scala/framework/memdomain/frontend/MemFrontend.scala
+++ b/arch/src/main/scala/framework/memdomain/frontend/MemFrontend.scala
@@ -94,11 +94,21 @@ class MemFrontend(val b: GlobalConfig)(edge: TLEdgeOut) extends Module {
   io.config <> configer.io.config
 
   // Connect query interfaces
-  // Use memLoader's query by default, memStorer will override when active
-  io.query_vbank_id              := Mux(memStorer.io.cmdReq.valid, memStorer.io.query_vbank_id, memLoader.io.query_vbank_id)
-  io.query_is_shared             := Mux(memStorer.io.cmdReq.valid, memStorer.io.query_is_shared, memLoader.io.query_is_shared)
+  // Preserve private store priority while keeping shared queries valid-gated.
+  val loaderSharedQuery = memLoader.io.query_is_shared
+  val storerSharedQuery = memStorer.io.query_is_shared
+  val storerIssueQuery  = memStorer.io.cmdReq.valid
+  val loaderIssueQuery  = memLoader.io.cmdReq.valid
+  val selectStorerQuery = storerIssueQuery || (!loaderIssueQuery && storerSharedQuery)
+
+  io.query_vbank_id              := Mux(selectStorerQuery, memStorer.io.query_vbank_id, memLoader.io.query_vbank_id)
+  io.query_is_shared             := Mux(selectStorerQuery, storerSharedQuery, loaderSharedQuery)
   memLoader.io.query_group_count := io.query_group_count
   memStorer.io.query_group_count := io.query_group_count
+
+  when(loaderSharedQuery && storerSharedQuery && memLoader.io.query_vbank_id =/= memStorer.io.query_vbank_id) {
+    assert(false.B, "MemFrontend shared query conflict: loader and storer query different vbanks in the same cycle\n")
+  }
 
 // -----------------------------------------------------------------------------
 // MemDecoder -> MemReservationStation

--- a/arch/src/main/scala/framework/memdomain/frontend/cmd/decoder/DomainDecoder.scala
+++ b/arch/src/main/scala/framework/memdomain/frontend/cmd/decoder/DomainDecoder.scala
@@ -135,7 +135,9 @@ class MemDomainDecoder(val b: GlobalConfig) extends Module {
 // -----------------------------------------------------------------------------
   io.mem_decode_cmd_o.valid := io.cmd_i.valid && (io.cmd_i.bits.domain_id === DomainId.MEM)
 
-  val raw_bank_id = rs1(bankIdLen - 1, 0)
+  // BB_BANK0 is encoded in rs1[9:0]. Use the full raw field to detect
+  // shared banks before truncating to the local vbank id width.
+  val raw_bank_id = rs1(9, 0)
   io.mem_decode_cmd_o.bits.is_shared    := io.mem_decode_cmd_o.valid && (raw_bank_id > 31.U)
   io.mem_decode_cmd_o.bits.is_load      := Mux(
     io.mem_decode_cmd_o.valid,

--- a/arch/src/main/scala/framework/memdomain/frontend/mem/MemLoader.scala
+++ b/arch/src/main/scala/framework/memdomain/frontend/mem/MemLoader.scala
@@ -146,8 +146,11 @@ class MemLoader(val b: GlobalConfig) extends Module {
   // Drive query interface
   // When idle and cmdReq is valid, query the incoming bank_id
   // Otherwise use the registered bank_id
+  val incomingLoadQuery = state === s_idle && io.cmdReq.valid && io.cmdReq.bits.cmd.is_load
+  val activeLoadQuery   = state =/= s_idle
+  val loadQueryActive   = incomingLoadQuery || activeLoadQuery
   io.query_vbank_id  := Mux(state === s_idle && io.cmdReq.valid, io.cmdReq.bits.cmd.bank_id, wr_bank_reg)
-  io.query_is_shared := Mux(state === s_idle && io.cmdReq.valid, io.cmdReq.bits.cmd.is_shared, is_shared_reg)
+  io.query_is_shared := loadQueryActive && Mux(incomingLoadQuery, io.cmdReq.bits.cmd.is_shared, is_shared_reg)
 
   // DMA req accepted
   when(io.dmaReq.fire) {

--- a/arch/src/main/scala/framework/memdomain/frontend/mem/MemStorer.scala
+++ b/arch/src/main/scala/framework/memdomain/frontend/mem/MemStorer.scala
@@ -107,8 +107,11 @@ class MemStorer(val b: GlobalConfig) extends Module {
   // Drive query interface
   // When idle and cmdReq is valid, query the incoming bank_id
   // Otherwise use the registered bank_id
+  val incomingStoreQuery = state === s_idle && io.cmdReq.valid && io.cmdReq.bits.cmd.is_store
+  val activeStoreQuery   = state =/= s_idle
+  val storeQueryActive   = incomingStoreQuery || activeStoreQuery
   io.query_vbank_id  := Mux(state === s_idle && io.cmdReq.valid, io.cmdReq.bits.cmd.bank_id, rd_bank_reg)
-  io.query_is_shared := Mux(state === s_idle && io.cmdReq.valid, io.cmdReq.bits.cmd.is_shared, is_shared_reg)
+  io.query_is_shared := storeQueryActive && Mux(incomingStoreQuery, io.cmdReq.bits.cmd.is_shared, is_shared_reg)
 
   // -----------------------------
   // SRAM read request

--- a/arch/src/main/scala/framework/system/core/accelerator/BuckyballAccelerator.scala
+++ b/arch/src/main/scala/framework/system/core/accelerator/BuckyballAccelerator.scala
@@ -54,6 +54,7 @@ class BuckyballAccelerator(val b: GlobalConfig)(edge: TLEdgeOut) extends Module 
     // Shared memory path — exposed to tile level for multi-core SharedMemBackend
     val shared_mem_req           = Vec(SharedMemLayout.channelPerHart(b), new MemRequestIO(b))
     val shared_config            = Decoupled(new MemConfigerIO(b))
+    val shared_query_valid       = Output(Bool())
     val shared_query_vbank_id    = Output(UInt(8.W))
     val shared_query_group_count = Input(UInt(log2Up(b.memDomain.bankNum + 1).W))
 
@@ -151,6 +152,7 @@ class BuckyballAccelerator(val b: GlobalConfig)(edge: TLEdgeOut) extends Module 
   // --- Shared memory passthrough ---
   io.shared_mem_req <> memDomain.io.shared_mem_req
   io.shared_config <> memDomain.io.shared_config
+  io.shared_query_valid                 := memDomain.io.shared_query_valid
   io.shared_query_vbank_id              := memDomain.io.shared_query_vbank_id
   memDomain.io.shared_query_group_count := io.shared_query_group_count
 

--- a/arch/src/main/scala/framework/system/tile/BBTile.scala
+++ b/arch/src/main/scala/framework/system/tile/BBTile.scala
@@ -641,10 +641,17 @@ class BBTileModuleImp(outer: BBTile) extends BaseTileModuleImp(outer) with HasIC
       }
       sharedBackend.io.config <> cfgArb.io.out
 
-      sharedBackend.io.query_vbank_id := enabledAccelerators.head.io.shared_query_vbank_id
       for (i <- 0 until nCores) {
-        accelerators(i).foreach { acc =>
-          acc.io.shared_query_group_count := sharedBackend.io.query_group_count
+        accelerators(i) match {
+          case Some(acc) =>
+            sharedBackend.io.query_valid(i)    := acc.io.shared_query_valid
+            sharedBackend.io.query_hart_id(i)  := hartIdForCore(i)
+            sharedBackend.io.query_vbank_id(i) := acc.io.shared_query_vbank_id
+            acc.io.shared_query_group_count    := sharedBackend.io.query_group_count(i)
+          case None      =>
+            sharedBackend.io.query_valid(i)    := false.B
+            sharedBackend.io.query_hart_id(i)  := 0.U
+            sharedBackend.io.query_vbank_id(i) := 0.U
         }
       }
     } else {

--- a/examples/chips/goban/arch/src/main/scala/CustomConfigs.scala
+++ b/examples/chips/goban/arch/src/main/scala/CustomConfigs.scala
@@ -10,10 +10,16 @@ class WithGobanHiddenHartIdBits(nTiles: Int, nCoresPerTile: Int, hiddenHartBase:
       case MaxHartIdBits => log2Ceil(hiddenHartBase + nTiles * (nCoresPerTile - 1))
     })
 
+class WithGobanHartIdBits(nTiles: Int, nCoresPerTile: Int)
+    extends Config((site, here, up) => {
+      case MaxHartIdBits => log2Ceil(nTiles * nCoresPerTile)
+    })
+
 /** 1 BBTile × 2 Buckyball cores. */
 class BuckyballGoban2CoreConfig
     extends Config(
-      new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t2c.toml") ++
+      new WithGobanHartIdBits(nTiles = 1, nCoresPerTile = 2) ++
+        new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t2c.toml") ++
         new chipyard.config.WithSystemBusWidth(128) ++
         new sims.base.BuckyballBaseConfig
     )
@@ -21,7 +27,8 @@ class BuckyballGoban2CoreConfig
 /** 1 BBTile × 4 Buckyball cores (default). */
 class BuckyballGoban4CoreConfig
     extends Config(
-      new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t4c.toml") ++
+      new WithGobanHartIdBits(nTiles = 1, nCoresPerTile = 4) ++
+        new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t4c.toml") ++
         new chipyard.config.WithSystemBusWidth(128) ++
         new sims.base.BuckyballBaseConfig
     )
@@ -29,7 +36,8 @@ class BuckyballGoban4CoreConfig
 /** 1 BBTile × 8 Buckyball cores. */
 class BuckyballGoban8CoreConfig
     extends Config(
-      new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t8c.toml") ++
+      new WithGobanHartIdBits(nTiles = 1, nCoresPerTile = 8) ++
+        new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t8c.toml") ++
         new chipyard.config.WithSystemBusWidth(128) ++
         new sims.base.BuckyballBaseConfig
     )
@@ -37,7 +45,8 @@ class BuckyballGoban8CoreConfig
 /** 1 BBTile × 16 Buckyball cores. */
 class BuckyballGoban16CoreConfig
     extends Config(
-      new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t16c.toml") ++
+      new WithGobanHartIdBits(nTiles = 1, nCoresPerTile = 16) ++
+        new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t16c.toml") ++
         new chipyard.config.WithSystemBusWidth(128) ++
         new sims.base.BuckyballBaseConfig
     )
@@ -45,7 +54,8 @@ class BuckyballGoban16CoreConfig
 /** 1 BBTile × 32 Buckyball cores. */
 class BuckyballGoban32CoreConfig
     extends Config(
-      new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t32c.toml") ++
+      new WithGobanHartIdBits(nTiles = 1, nCoresPerTile = 32) ++
+        new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t32c.toml") ++
         new chipyard.config.WithSystemBusWidth(128) ++
         new sims.base.BuckyballBaseConfig
     )
@@ -53,7 +63,8 @@ class BuckyballGoban32CoreConfig
 /** 1 BBTile × 64 Buckyball cores. */
 class BuckyballGoban64CoreConfig
     extends Config(
-      new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t64c.toml") ++
+      new WithGobanHartIdBits(nTiles = 1, nCoresPerTile = 64) ++
+        new WithBuckyballTiles("../examples/chips/goban/arch/src/main/scala/configs/1t64c.toml") ++
         new chipyard.config.WithSystemBusWidth(128) ++
         new sims.base.BuckyballBaseConfig
     )

--- a/examples/chips/goban/workloads/ctests/CMakeLists.txt
+++ b/examples/chips/goban/workloads/ctests/CMakeLists.txt
@@ -20,6 +20,7 @@ function(add_goban_test_target TEST_NAME SOURCE_FILE)
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${EXECUTABLE}
     COMMAND ${ELF_CC} ${GOBAN_C_FLAGS}
+      ${ARGN}
       -o ${EXECUTABLE}
       ${GOBAN_CTEST_DIR}/start.S
       ${GOBAN_CTEST_DIR}/${SOURCE_FILE}
@@ -95,6 +96,17 @@ endfunction()
 
 add_goban_test_target(goban_barrier_test barrier_test.c)
 add_goban_test_target(goban_barrier_mvin_test barrier_mvin_test.c)
+add_goban_test_target(goban_shared_barrier_mvin_test shared_barrier_mvin_test.c)
+add_goban_test_target(goban_shared_same_vbank_test shared_same_vbank_test.c)
+add_goban_test_target(goban_shared_multigroup_mvin_test shared_multigroup_mvin_test.c)
+add_goban_test_target(goban_shared_duplicate_alloc_assert_test shared_duplicate_alloc_assert_test.c)
+add_goban_test_target(goban_shared_invalid_release_assert_test shared_invalid_release_assert_test.c)
+add_goban_test_target(goban_shared_barrier_mvin_2core_test shared_barrier_mvin_test.c -DNCORES=2 -DGOBAN_CORES_PER_TILE=2 -DGOBAN_MAX_TILES=1)
+add_goban_test_target(goban_shared_same_vbank_2core_test shared_same_vbank_test.c -DNCORES=2 -DGOBAN_CORES_PER_TILE=2 -DGOBAN_MAX_TILES=1)
+add_goban_test_target(goban_shared_multigroup_mvin_2core_test shared_multigroup_mvin_test.c -DNCORES=2 -DGOBAN_CORES_PER_TILE=2 -DGOBAN_MAX_TILES=1)
+add_goban_test_target(goban_shared_barrier_mvin_8core_test shared_barrier_mvin_test.c -DNCORES=8 -DGOBAN_CORES_PER_TILE=8 -DGOBAN_MAX_TILES=1)
+add_goban_test_target(goban_shared_same_vbank_8core_test shared_same_vbank_test.c -DNCORES=8 -DGOBAN_CORES_PER_TILE=8 -DGOBAN_MAX_TILES=1)
+add_goban_test_target(goban_shared_multigroup_mvin_8core_test shared_multigroup_mvin_test.c -DNCORES=8 -DGOBAN_CORES_PER_TILE=8 -DGOBAN_MAX_TILES=1)
 add_goban_2t4c_test_target(goban_hetero_2t4c_smoke_test hetero_64t4c_smoke_test.c)
 add_goban_64t4c_test_target(goban_hetero_64t4c_smoke_test hetero_64t4c_smoke_test.c)
 add_goban_2t4c_test_target(goban_uart_rx_echo_2t4c_test uart_rx_echo_test.c)
@@ -104,6 +116,15 @@ add_custom_target(goban-ctests-build ALL
   DEPENDS
     goban_barrier_test-ctest-build
     goban_barrier_mvin_test-ctest-build
+    goban_shared_barrier_mvin_test-ctest-build
+    goban_shared_same_vbank_test-ctest-build
+    goban_shared_multigroup_mvin_test-ctest-build
+    goban_shared_barrier_mvin_2core_test-ctest-build
+    goban_shared_same_vbank_2core_test-ctest-build
+    goban_shared_multigroup_mvin_2core_test-ctest-build
+    goban_shared_barrier_mvin_8core_test-ctest-build
+    goban_shared_same_vbank_8core_test-ctest-build
+    goban_shared_multigroup_mvin_8core_test-ctest-build
     goban_hetero_2t4c_smoke_test-ctest-build
     goban_hetero_64t4c_smoke_test-ctest-build
     goban_uart_rx_echo_2t4c_test-ctest-build

--- a/examples/chips/goban/workloads/ctests/shared_barrier_mvin_test.c
+++ b/examples/chips/goban/workloads/ctests/shared_barrier_mvin_test.c
@@ -1,0 +1,114 @@
+/*
+ * shared_barrier_mvin_test.c - Goban multi-core shared-bank mvin/mvout + barrier test.
+ *
+ * SPMD: all NCORES hardware threads run this program simultaneously.
+ *
+ * Each participating core:
+ *   1. Allocates its own shared bank (bank = bb_shared_bank(cid)).
+ *   2. Fills the bank with a core-specific pattern (mvin).
+ *   3. Reads it back (mvout) and verifies locally.
+ *   4. Calls bb_barrier() - waits for all participating cores.
+ *   5. Core 0 prints the summary.
+ *
+ * This test is intentionally separate from barrier_mvin_test.c, which remains
+ * the private-bank mvin/mvout + barrier smoke test.
+ *
+ * This test exercises:
+ *   - Per-core shared-bank mvin/mvout
+ *   - bb_barrier() synchronization across all participating cores
+ *   - Parallel hardware accelerator utilization
+ */
+
+#include "goban.h"
+#include "scu.h"
+#include <string.h>
+
+static void log_core_msg(int hart, int cid, const char *msg) {
+  scu_puts(hart, "[core ");
+  scu_put_u32(hart, (uint32_t)cid);
+  scu_puts(hart, "] ");
+  scu_puts(hart, msg);
+  scu_putc(hart, '\n');
+}
+
+static void log_mismatch(int hart, int cid, int idx, elem_t got, elem_t expected) {
+  scu_puts(hart, "[core ");
+  scu_put_u32(hart, (uint32_t)cid);
+  scu_puts(hart, "] ERROR: mvout mismatch idx=");
+  scu_put_u32(hart, (uint32_t)idx);
+  scu_puts(hart, " got=");
+  scu_put_u32(hart, (uint32_t)got);
+  scu_puts(hart, " expected=");
+  scu_put_u32(hart, (uint32_t)expected);
+  scu_putc(hart, '\n');
+}
+
+static void log_summary(int hart, const char *status) {
+  scu_puts(hart, "=== shared_barrier_mvin_test ");
+  scu_puts(hart, status);
+  scu_puts(hart, " ===\n");
+}
+
+#define DIM    16
+#ifndef NCORES
+#define NCORES 4
+#endif
+
+/* Per-core scratchpad buffers. The compiler places these in BSS (all harts share
+   the same virtual address space, but each core writes its own slot). */
+static elem_t  src[NCORES][DIM * DIM] __attribute__((aligned(128)));
+static elem_t  dst[NCORES][DIM * DIM] __attribute__((aligned(128)));
+static volatile int core_ok[NCORES];
+
+int main(void) {
+  int hart = bb_get_hart_id();
+  int cid = bb_get_core_id();
+
+  log_core_msg(hart, cid, "starting shared mvin/mvout");
+
+  /* ---- Step 1: fill src with a core-specific pattern ---- */
+  elem_t pat = (elem_t)(cid + 1);
+  for (int i = 0; i < DIM * DIM; i++) {
+    src[cid][i] = pat;
+  }
+
+  /* ---- Step 2: mvin -> shared bank <cid> ---- */
+  int bank = bb_shared_bank(cid);   /* force the decoder onto the shared path */
+  bb_mem_alloc(bank, 1, 1);
+  bb_mvin((uintptr_t)src[cid], bank, DIM, 1);
+
+  /* ---- Step 3: mvout -> dst ---- */
+  memset(dst[cid], 0, sizeof(dst[cid]));
+  bb_mvout((uintptr_t)dst[cid], bank, DIM, 1);
+  bb_fence();
+  bb_mem_release(bank);
+
+  /* ---- Step 4: verify locally ---- */
+  int ok = 1;
+  for (int i = 0; i < DIM * DIM; i++) {
+    if (dst[cid][i] != pat) {
+      log_mismatch(hart, cid, i, dst[cid][i], pat);
+      ok = 0;
+      break;
+    }
+  }
+  core_ok[cid] = ok;
+  log_core_msg(hart, cid, ok ? "shared mvin/mvout PASSED" : "shared mvin/mvout FAILED");
+
+  /* ============ BARRIER: wait for all cores to finish ============ */
+  bb_barrier();
+
+  /* ---- Step 5: core 0 collects results ---- */
+  if (cid == 0) {
+    int all_ok = 1;
+    for (int i = 0; i < NCORES; i++) {
+      if (!core_ok[i]) {
+        all_ok = 0;
+        scu_puts(hart, "[core 0] a core reported FAILED\n");
+      }
+    }
+    log_summary(hart, all_ok ? "PASSED" : "FAILED");
+  }
+
+  return core_ok[cid] ? 0 : 1;
+}

--- a/examples/chips/goban/workloads/ctests/shared_duplicate_alloc_assert_test.c
+++ b/examples/chips/goban/workloads/ctests/shared_duplicate_alloc_assert_test.c
@@ -1,0 +1,23 @@
+/*
+ * shared_duplicate_alloc_assert_test.c - expected-fail assertion test.
+ *
+ * This test should trip SharedMemBackend duplicate allocation assertion because
+ * core 0 allocates the same (hart, shared vbank, group) twice.
+ */
+
+#include "goban.h"
+#include "scu.h"
+
+int main(void) {
+  int hart = bb_get_hart_id();
+  int cid = bb_get_core_id();
+  if (cid == 0) {
+    int bank = bb_shared_bank(0);
+    scu_puts(hart, "=== shared_duplicate_alloc_assert_test starting ===\n");
+    bb_mem_alloc(bank, 1, 1);
+    bb_mem_alloc(bank, 1, 1);
+    scu_puts(hart, "ERROR: duplicate allocation assertion did not fire\n");
+    return 1;
+  }
+  return 0;
+}

--- a/examples/chips/goban/workloads/ctests/shared_invalid_release_assert_test.c
+++ b/examples/chips/goban/workloads/ctests/shared_invalid_release_assert_test.c
@@ -1,0 +1,21 @@
+/*
+ * shared_invalid_release_assert_test.c - expected-fail assertion test.
+ *
+ * This test should trip SharedMemBackend release-missing assertion because
+ * core 0 releases a shared vbank that was never allocated.
+ */
+
+#include "goban.h"
+#include "scu.h"
+
+int main(void) {
+  int hart = bb_get_hart_id();
+  int cid = bb_get_core_id();
+  if (cid == 0) {
+    scu_puts(hart, "=== shared_invalid_release_assert_test starting ===\n");
+    bb_mem_release(bb_shared_bank(7));
+    scu_puts(hart, "ERROR: invalid release assertion did not fire\n");
+    return 1;
+  }
+  return 0;
+}

--- a/examples/chips/goban/workloads/ctests/shared_multigroup_mvin_test.c
+++ b/examples/chips/goban/workloads/ctests/shared_multigroup_mvin_test.c
@@ -1,0 +1,86 @@
+/*
+ * shared_multigroup_mvin_test.c - Goban shared multi-group mvin/mvout test.
+ *
+ * Each core allocates a two-group shared bank and verifies that group_count
+ * query drives the loader/storer across both groups.
+ */
+
+#include "goban.h"
+#include "scu.h"
+#include <string.h>
+
+#define ROWS 16
+#define ROW_ELEMS 16
+#define GROUPS 2
+#ifndef NCORES
+#define NCORES 4
+#endif
+#define ELEMS (ROWS * ROW_ELEMS * GROUPS)
+
+static elem_t src[NCORES][ELEMS] __attribute__((aligned(128)));
+static elem_t dst[NCORES][ELEMS] __attribute__((aligned(128)));
+static volatile int core_ok[NCORES];
+
+static void log_msg(int hart, int cid, const char *msg) {
+  scu_puts(hart, "[core ");
+  scu_put_u32(hart, (uint32_t)cid);
+  scu_puts(hart, "] ");
+  scu_puts(hart, msg);
+  scu_putc(hart, '\n');
+}
+
+static void log_mismatch(int hart, int cid, int idx, elem_t got, elem_t exp) {
+  scu_puts(hart, "[core ");
+  scu_put_u32(hart, (uint32_t)cid);
+  scu_puts(hart, "] ERROR: idx=");
+  scu_put_u32(hart, (uint32_t)idx);
+  scu_puts(hart, " got=");
+  scu_put_u32(hart, (uint32_t)got);
+  scu_puts(hart, " expected=");
+  scu_put_u32(hart, (uint32_t)exp);
+  scu_putc(hart, '\n');
+}
+
+int main(void) {
+  int hart = bb_get_hart_id();
+  int cid = bb_get_core_id();
+  int bank = bb_shared_bank(cid);
+
+  for (int i = 0; i < ELEMS; i++) {
+    src[cid][i] = (elem_t)(cid * 11 + (i & 0x7f));
+  }
+
+  bb_mem_alloc(bank, 1, GROUPS);
+  bb_mvin((uintptr_t)src[cid], bank, ROWS, 1);
+  memset(dst[cid], 0, sizeof(dst[cid]));
+  bb_mvout((uintptr_t)dst[cid], bank, ROWS, 1);
+  bb_fence();
+  bb_mem_release(bank);
+
+  int ok = 1;
+  for (int i = 0; i < ELEMS; i++) {
+    if (dst[cid][i] != src[cid][i]) {
+      log_mismatch(hart, cid, i, dst[cid][i], src[cid][i]);
+      ok = 0;
+      break;
+    }
+  }
+  core_ok[cid] = ok;
+  log_msg(hart, cid, ok ? "multi-group shared test PASSED" : "multi-group shared test FAILED");
+
+  bb_barrier();
+
+  if (cid == 0) {
+    int all_ok = 1;
+    for (int i = 0; i < NCORES; i++) {
+      if (!core_ok[i]) {
+        all_ok = 0;
+      }
+    }
+    scu_puts(hart, "=== shared_multigroup_mvin_test ");
+    scu_puts(hart, all_ok ? "PASSED" : "FAILED");
+    scu_puts(hart, " ===\n");
+  }
+
+  return core_ok[cid] ? 0 : 1;
+}

--- a/examples/chips/goban/workloads/ctests/shared_same_vbank_test.c
+++ b/examples/chips/goban/workloads/ctests/shared_same_vbank_test.c
@@ -1,0 +1,85 @@
+/*
+ * shared_same_vbank_test.c - Goban shared query isolation test.
+ *
+ * All cores allocate the same shared vbank id. Correct behavior requires the
+ * SharedMemBackend query and access paths to key mappings by (hart, vbank).
+ */
+
+#include "goban.h"
+#include "scu.h"
+#include <string.h>
+
+#define ROWS 16
+#define ROW_ELEMS 16
+#ifndef NCORES
+#define NCORES 4
+#endif
+
+static elem_t src[NCORES][ROWS * ROW_ELEMS] __attribute__((aligned(128)));
+static elem_t dst[NCORES][ROWS * ROW_ELEMS] __attribute__((aligned(128)));
+static volatile int core_ok[NCORES];
+
+static void log_msg(int hart, int cid, const char *msg) {
+  scu_puts(hart, "[core ");
+  scu_put_u32(hart, (uint32_t)cid);
+  scu_puts(hart, "] ");
+  scu_puts(hart, msg);
+  scu_putc(hart, '\n');
+}
+
+static void log_mismatch(int hart, int cid, int idx, elem_t got, elem_t exp) {
+  scu_puts(hart, "[core ");
+  scu_put_u32(hart, (uint32_t)cid);
+  scu_puts(hart, "] ERROR: idx=");
+  scu_put_u32(hart, (uint32_t)idx);
+  scu_puts(hart, " got=");
+  scu_put_u32(hart, (uint32_t)got);
+  scu_puts(hart, " expected=");
+  scu_put_u32(hart, (uint32_t)exp);
+  scu_putc(hart, '\n');
+}
+
+int main(void) {
+  int hart = bb_get_hart_id();
+  int cid = bb_get_core_id();
+  int bank = bb_shared_bank(0);
+  elem_t pat = (elem_t)(cid + 3);
+
+  for (int i = 0; i < ROWS * ROW_ELEMS; i++) {
+    src[cid][i] = pat;
+  }
+
+  bb_mem_alloc(bank, 1, 1);
+  bb_mvin((uintptr_t)src[cid], bank, ROWS, 1);
+  memset(dst[cid], 0, sizeof(dst[cid]));
+  bb_mvout((uintptr_t)dst[cid], bank, ROWS, 1);
+  bb_fence();
+  bb_mem_release(bank);
+
+  int ok = 1;
+  for (int i = 0; i < ROWS * ROW_ELEMS; i++) {
+    if (dst[cid][i] != pat) {
+      log_mismatch(hart, cid, i, dst[cid][i], pat);
+      ok = 0;
+      break;
+    }
+  }
+  core_ok[cid] = ok;
+  log_msg(hart, cid, ok ? "same-vbank shared test PASSED" : "same-vbank shared test FAILED");
+
+  bb_barrier();
+
+  if (cid == 0) {
+    int all_ok = 1;
+    for (int i = 0; i < NCORES; i++) {
+      if (!core_ok[i]) {
+        all_ok = 0;
+      }
+    }
+    scu_puts(hart, "=== shared_same_vbank_test ");
+    scu_puts(hart, all_ok ? "PASSED" : "FAILED");
+    scu_puts(hart, " ===\n");
+  }
+
+  return core_ok[cid] ? 0 : 1;
+}


### PR DESCRIPTION
修改内容：
- 修复 MemDomainDecoder 的 shared bank 判断，避免 `bb_shared_bank(0)` 在路由前被截断并误走 private bank 0。
- 修复 MemFrontend 的 query 仲裁，在保留 private store issue 优先级的同时支持 valid-gated shared query，避免 private store 采样错误的 `group_count`。
- 将 shared group-count query 改为按 core 独立查询，并显式携带 valid/hart/vbank，避免 Goban 多核场景下把 core0 的查询结果广播给所有 core。
- 收敛 MemLoader/MemStorer 的 shared query 生命周期，避免 shared 操作完成或 release 后继续输出 stale query。
- 增加 SharedMemBackend 的 shared allocation/release 一致性检查，覆盖 duplicate allocation、invalid release 和 no-free-pbank 场景。
- 补充 Goban shared memory 回归测试，覆盖 shared barrier mvin/mvout、同 vbank 不同 hart、multi-group allocation，以及 duplicate/invalid expected-fail assertion。
- 补充 2-core 和 8-core shared memory 正向测试 variant。

验证情况：
- `nix build`、Toy workload 和 Toy Verilator 模型构建：PASS。
- 针对上次 CI 失败的 21 个 Toy single-core Verilator 用例逐项复跑：21/21 PASS，包括 `vecunit_matmul_16xn_random3`、`gemmini_os_risc_basic_test` 和 `transpose_matmul`。
- Goban private barrier/mvin 回归：PASS，原 private mvin/mvout + barrier 覆盖保留。
- Goban4 shared barrier mvin/mvout 完整仿真：PASS。
- Goban2/Goban4/Goban8 shared regression 矩阵：PASS。
  - shared barrier mvin/mvout
  - same-vbank different-hart
  - multi-group mvin/mvout
- expected-fail 测试已手动验证：
  - duplicate shared allocation 触发 `SharedMemBackend duplicate allocation`
  - invalid shared release 触发 `SharedMemBackend release missing allocation`
- `git diff --check`：PASS。

说明：
- 本 PR 聚焦 shared memory 多核访问正确性。
- 当前 bebop Verilator native helper 固定引用 32 个 private banks，而 Goban 配置只生成 16 个 private banks；干净上游 bebop 因而无法直接构建 Goban Verilator 模型。Goban 仿真使用未提交的本地 compatibility shim 完成，本 PR 不修改 bebop 或子模块指针。
- shared memory routing 的硬件开销问题尚未在本 PR 中解决，后续仍需要继续优化 shared router/interconnect 结构。
