### PR TITLE
fix: remove stale BUDDY_EXTERNAL_DIALECTS_DIR and add missing dpi_mtr…

### DIFF
--- a/arch/src/csrc/src/monitor/trace/mtrace.cc
+++ b/arch/src/csrc/src/monitor/trace/mtrace.cc
@@ -63,3 +63,28 @@ extern "C" void dpi_mtrace(unsigned char is_write, // 1 = write, 0 = read
     fflush(mtrace_fp);
   }
 }
+
+// DPI-C function for memory trace issue (mtrace_issue)
+// Called when MemMidend issues memory operations
+extern "C" void dpi_mtrace_issue(unsigned int hart_id_lo,
+                                 unsigned int hart_id_hi,
+                                 unsigned char is_shared, unsigned int rob_id,
+                                 unsigned int vbank_id, unsigned int group_id) {
+  if (!bdb_trace_on(BDB_TR_MTRACE)) {
+    return;
+  }
+  init_mtrace();
+
+  unsigned long long hart_id =
+      ((unsigned long long)hart_id_hi << 32) | hart_id_lo;
+
+  if (mtrace_fp) {
+    fprintf(mtrace_fp,
+            "{\"type\":\"mtrace_issue\",\"clk\":%llu,\"event\":\"issue\","
+            "\"hart_id\":%llu,\"is_shared\":%u,\"rob_id\":%u,\"vbank_id\":%u,"
+            "\"group_id\":%u}\n",
+            (unsigned long long)bdb_rtl_clk, hart_id, is_shared, rob_id,
+            vbank_id, group_id);
+    fflush(mtrace_fp);
+  }
+}

--- a/scripts/nix/build-all.sh
+++ b/scripts/nix/build-all.sh
@@ -122,7 +122,6 @@ if run_step "2"; then
   ninja -C llvm/build #check-clang check-mlir check-openmp
 
   cmake -G Ninja -S . -B build \
-    -DBUDDY_EXTERNAL_DIALECTS_DIR=${BBDIR}/examples/chips/toy/compiler \
     -DMLIR_DIR=$PWD/llvm/build/lib/cmake/mlir \
     -DLLVM_DIR=$PWD/llvm/build/lib/cmake/llvm \
     -DLLVM_ENABLE_ASSERTIONS=ON \


### PR DESCRIPTION
…ace_issue stub

- Delete -DBUDDY_EXTERNAL_DIALECTS_DIR line: examples/chips/toy/compiler no longer exists
- Add dpi_mtrace_issue implementation: Scala side declares this DPI but C++ stub was missing, causing Verilator linker error 'undefined symbol'