### PR TITLE
Fix Verilator difftest chip runtime resolution

### DIFF
--- a/examples/cores/pebble/emu/src/lib.rs
+++ b/examples/cores/pebble/emu/src/lib.rs
@@ -1,4 +1,4 @@
-pub const BEMU_TOP_CONFIG: &str = "../../core.toml";
+pub const BEMU_TOP_CONFIG: &str = "../../../../chips/pebble/configs/pebble.toml";
 
 pub fn bemu_top_config() -> &'static str {
     BEMU_TOP_CONFIG

--- a/examples/cores/toy/emu/src/lib.rs
+++ b/examples/cores/toy/emu/src/lib.rs
@@ -1,4 +1,4 @@
-pub const BEMU_TOP_CONFIG: &str = "../../core.toml";
+pub const BEMU_TOP_CONFIG: &str = "../../../../chips/toy/configs/toy.toml";
 
 pub fn bemu_top_config() -> &'static str {
     BEMU_TOP_CONFIG


### PR DESCRIPTION
## Summary
- update the `bbdev` submodule to resolve BEMU manifests from `[runtime].bemu`
- point Toy and Pebble BEMU defaults at their chip-level topology TOMLs
- restore the Chip → Tile → Core topology flow required by Bebop PR #14

## Dependency
- DangoSys/bbdev#12

## Root cause
`bbdev bebop-verilator --build --diff` still looked for `examples/chips/toy/emu/Cargo.toml`, which was removed when Toy/Pebble emulator crates moved under `examples/cores`. Resolving `runtime.bemu` fixes the location, while the top-config changes ensure Bebop parses a `[[tiles]]` topology rather than a Core TOML.

## Verification
- pre-commit hooks passed
- Python syntax checks passed
- runtime manifest resolution checked across current chip layouts
- Toy/Pebble topology TOMLs contain `[[tiles]]`
- Cargo metadata and Rustfmt checks passed
- `git diff --check` passed

Full build/simulation was not invoked because the required Buckyball MCP workflow tools were unavailable in the active session.