### PR TITLE
[build] fix: add python3Packages to flake buildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
             hardeningDisable = [ "libcxxhardeningfast" ];
 
             buildInputs = with pkgs; [
+	      python.python3Packages
               clibs.zlib-dev
               clibs.zlib
               clibs.lz4-dev


### PR DESCRIPTION
Add python.python3Packages to flake buildInputs so the build environment has the full Python 3 package set available.