### PR TITLE
fix(arch): align Mill modules with updated Chipyard

### DIFF
--- a/arch/build.sc
+++ b/arch/build.sc
@@ -344,9 +344,10 @@ object nvdla extends SbtModule {
     os.pwd / "thirdparty" / "chipyard" / "generators" / "nvdla"
   override def scalaVersion = "2.13.16"
 
-  // Add rocket-chip as a dependency
+  // NVDLA config fragments use the subsystem injector API from testchipip.
   override def moduleDeps = Seq(
-    rocketchip
+    rocketchip,
+    testchipip
   )
 
   override def ivyDeps = Agg(
@@ -365,10 +366,11 @@ object fft_generator extends SbtModule {
     os.pwd / "thirdparty" / "chipyard" / "generators" / "fft-generator"
   override def scalaVersion = "2.13.16"
 
-  // Add rocket-chip and rocket-dsp-utils as dependencies (as per build.sbt)
+  // FFT configs use the subsystem injector API from testchipip.
   override def moduleDeps = Seq(
     rocketchip,
-    rocket_dsp_utils
+    rocket_dsp_utils,
+    testchipip
   )
 
   override def ivyDeps = Agg(
@@ -967,7 +969,10 @@ object firechip_bridgestubs extends SbtModule {
 
   // Add chipyard, firesim_lib, and firechip_bridgeinterfaces as dependencies
   override def sources = T.sources {
-    super.sources().filterNot(path => path.path.last.toString == "SimpleNICBridge.scala")
+    os.walk(millSourcePath / "src" / "main" / "scala")
+      .filter(path => path.ext == "scala")
+      .filterNot(path => path.last.toString == "SimpleNICBridge.scala")
+      .map(PathRef(_))
   }
 
   override def moduleDeps = Seq(


### PR DESCRIPTION
## Summary

- add the `testchipip` module dependency required by updated NVDLA and FFT config fragments
- enumerate FireChip bridge stub Scala sources directly while excluding `SimpleNICBridge.scala`

## Validation

- `nix develop -c sh -lc 'cd arch && mill -i nvdla.compile fft_generator.compile firechip_bridgestubs.compile'`
- repository pre-commit hooks: PASS