### PR TITLE
chore(nix): add rust-analyzer to the development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,6 +148,7 @@
               rustTools.cargoNextest
               rustTools.rustfmt
               rustTools.clippy
+              rustTools.rustAnalyzer
 
               # bbdev dependencies
               bbdev.iii

--- a/scripts/nix/build-env-rust.nix
+++ b/scripts/nix/build-env-rust.nix
@@ -7,4 +7,5 @@
   cargoNextest = pkgs.cargo-nextest;
   rustfmt = pkgs.rustfmt;
   clippy = pkgs.clippy;
+  rustAnalyzer = pkgs.rust-analyzer;
 }


### PR DESCRIPTION
## Summary

- expose `pkgs.rust-analyzer` through the shared Rust tool bundle
- include it in the default Buckyball Nix development shell

## Validation

- `nix develop -c rust-analyzer --version`
- result: `rust-analyzer 2026-06-15`
- repository pre-commit hooks: PASS