### PR TITLE
[CI] Serialize shared runner checkouts

### DIFF
--- a/.github/scripts/ci_repo_lock.sh
+++ b/.github/scripts/ci_repo_lock.sh
@@ -23,9 +23,9 @@ exec 9>"${LOCK_FILE}"
 
 repo_reset() {
   cd "${repo}"
-  git fetch --force --prune origin "${git_ref}"
-  git checkout --detach FETCH_HEAD
-  git reset --hard FETCH_HEAD
+  git fetch --force --prune origin "${want_sha}"
+  git checkout --detach "${want_sha}"
+  git reset --hard "${want_sha}"
   git clean -ffd
   git submodule sync
   git submodule update --init --force

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,7 +13,7 @@ permissions:
   checks: write
 
 concurrency:
-  group: buckyball-ci-${{ github.event.pull_request.head.sha || github.sha }}
+  group: buckyball-ci-check
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
Serialize workflow runs that share the self-hosted `~/Code/buckyball` checkout, while keeping the chip matrix parallel. Fetch and checkout the immutable workflow SHA instead of a mutable ref.